### PR TITLE
Add build: . to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       ofelia.job-run.awwesome.container: 'awwesome'
   source:
     image: mkitzmann/awwesome:latest
+    build: .
     container_name: awwesome
     restart: no
     environment:


### PR DESCRIPTION
https://github.com/mkitzmann/awwesome/issues/21

If `build: .` is added to the docker-compose.yml file in the `source:` stanza, that will enable docker to build the image locally if there is not am image of the correct architecture in dockerhub.



Before adding `build: .`
```
pi@raspberrypi:~/docker/awwesome $ docker-compose up -d
Pulling source (mkitzmann/awwesome:)...
latest: Pulling from mkitzmann/awwesome
ERROR: no matching manifest for linux/arm/v8 in the manifest list entries
``` 



After:
```
pi@raspberrypi:~/docker/awwesome $ docker-compose up -d
Building source
[+] Building 2.1s (10/10) FINISHED
 => [internal] load .dockerignore                                                                                                  0.2s
 => => transferring context: 95B                                                                                                   0.0s
 => [internal] load build definition from Dockerfile                                                                               0.1s
 => => transferring dockerfile: 124B                                                                                               0.0s
 => [internal] load metadata for docker.io/library/node:20-slim                                                                    0.9s
 => [internal] load build context                                                                                                  0.2s
 => => transferring context: 1.93MB                                                                                                0.1s
 => [1/5] FROM docker.io/library/node:20-slim@sha256:b952b58c5aaf0b46510f8789a3a710515bb1b881963e1b9c6b7917b323911999              0.0s
 => CACHED [2/5] WORKDIR /usr/src/app                                                                                              0.0s
 => CACHED [3/5] COPY package*.json ./                                                                                             0.0s
 => CACHED [4/5] RUN npm ci                                                                                                        0.0s
 => [5/5] COPY . .                                                                                                                 0.4s
 => exporting to image                                                                                                             0.2s
 => => exporting layers                                                                                                            0.2s
 => => writing image sha256:70536fab38e11e9fe5ff301b96630a611ffcbac8a06b6cd7e25eb074c1e810e7                                       0.0s
 => => naming to docker.io/mkitzmann/awwesome:latest                                                                               0.0s
WARNING: Image for service source was built because it did not already exist. To rebuild this image you must use `docker-compose build` or `docker-compose up --build`.
Pulling ofelia (mcuadros/ofelia:latest)...
latest: Pulling from mcuadros/ofelia
fda0ff469afd: Already exists
ac5ad2b4a494: Pull complete
4574b7cb3872: Pull complete
Digest: sha256:9478fec5cbcbad325c01b3d76523d44ebccb7f62c153c1389335a0a46f05c58e
Status: Downloaded newer image for mcuadros/ofelia:latest
Pulling web (nginx:)...
latest: Pulling from library/nginx
c5c3540d9b4f: Already exists
826c5a0e34a3: Pull complete
bf5aa3492bf4: Pull complete
03573142ac47: Pull complete
b82572e74e7f: Pull complete
dfdad29d9234: Pull complete
af048b461f9f: Pull complete
Digest: sha256:6db391d1c0cfb30588ba0bf72ea999404f2764febf0f1f196acd5867ac7efa7e
Status: Downloaded newer image for nginx:latest
Creating awwesome ... done
Creating nginx    ... done
Creating ofelia   ... done
```