### PR TITLE
fix container security hardening and path handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ COPY package.json ./
 COPY scripts ./scripts
 COPY src/lib/server/db/schema.ts ./src/lib/server/db/schema.ts
 COPY docker-entrypoint.sh ./
+RUN mkdir -p /usr/src/app/data && chown -R node:node /usr/src/app
 EXPOSE 3000
 ENV NODE_ENV=production
+USER node
 ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,13 @@ services:
       - PUBLIC_ANALYTICS_URL=${PUBLIC_ANALYTICS_URL}
       - PUBLIC_ANALYTICS_WEBSITE_ID=${PUBLIC_ANALYTICS_WEBSITE_ID}
       - TOKEN_GITHUB=${TOKEN_GITHUB}
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
     volumes:
       - data:/usr/src/app/data
+    tmpfs:
+      - /tmp
     deploy:
       replicas: 1
       update_config:

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -15,12 +15,20 @@ export const handle: Handle = async ({ event, resolve }) => {
 
 let running = false;
 
-function runScript(label: string, script: string): Promise<number | null> {
+const SCRIPT_PATHS = {
+	seed: path.resolve('scripts/seed.ts'),
+	backfillStars: path.resolve('scripts/backfill-stars.ts')
+} as const;
+
+type ScriptKey = keyof typeof SCRIPT_PATHS;
+
+function runScript(label: string, scriptKey: ScriptKey): Promise<number | null> {
 	return new Promise((resolve) => {
 		const tsxBin = path.resolve('node_modules/.bin/tsx');
+		const scriptPath = SCRIPT_PATHS[scriptKey];
 		console.log(`[${label}] Starting at ${new Date().toISOString()}`);
 
-		const child = spawn(tsxBin, [path.resolve(script)], {
+		const child = spawn(tsxBin, [scriptPath], {
 			cwd: path.resolve('.'),
 			stdio: 'inherit'
 		});
@@ -44,10 +52,10 @@ async function runDaily() {
 	running = true;
 
 	try {
-		const seedCode = await runScript('seed', 'scripts/seed.ts');
+		const seedCode = await runScript('seed', 'seed');
 		if (seedCode === 0) {
 			invalidateCaches();
-			await runScript('backfill-stars', 'scripts/backfill-stars.ts');
+			await runScript('backfill-stars', 'backfillStars');
 		}
 	} finally {
 		running = false;


### PR DESCRIPTION
## Summary
- run container processes as a non-root user (`USER node`) in `Dockerfile`
- harden `docker-compose.yml` with:
  - `security_opt: no-new-privileges:true`
  - `read_only: true`
  - `tmpfs: /tmp`
- refactor script execution in `src/hooks.server.ts` to use an allowlisted script map instead of dynamic path resolution

## Why
These changes address Semgrep security findings and reduce container breakout / privilege-escalation risk while keeping runtime behavior unchanged.

## Validation
- [x] `yarn format`
- [x] `yarn lint`
- [x] `yarn test --run`

## Security findings addressed
- `dockerfile.security.missing-user-entrypoint.missing-user-entrypoint`
- `yaml.docker-compose.security.no-new-privileges.no-new-privileges`
- `yaml.docker-compose.security.writable-filesystem-service.writable-filesystem-service`
- `javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal` (mitigation via allowlisted internal script paths)

## Notes
- persistent app data remains writable via mounted volume: `/usr/src/app/data`
- temporary writes are supported via `tmpfs` at `/tmp`